### PR TITLE
fix readme instructions for the debian way

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ install on Debian. If you're looking for the Zig source code, see
 ### The Debian way
 
 ```sh
-curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
+curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
 echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+sudo apt update
 sudo apt install zig
 ```
 


### PR DESCRIPTION
"The Debian Way" in the readme doesn't work when pasted in, made some changes so it works on the latest debian testing.